### PR TITLE
Feature get name without path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ tutorials/results.csv
 tutorials/.ipynb_checkpoints
 powerfactory_projects
 py_venv
+*.csv
 .vscode

--- a/src/powfacpy/base_interface.py
+++ b/src/powfacpy/base_interface.py
@@ -862,26 +862,24 @@ class PFStringManipulation:
     get_without_classname=False,
     ):
 
+    is_list = True
     if not type(powerfactory_objects) == list:
       powerfactory_objects = [powerfactory_objects,]
-    
-    name_strings = [
-      x.GetFullName() for x in  powerfactory_objects
-    ]
+      is_list = False
 
-    def _get_part_after_last_slash(x:str):
-      return x.split('\\')[-1]
-    
-    def _remove_classname(x:str):
-      return x.split('.')[0]
+    names_without_path = []
+    for powerfactory_object in powerfactory_objects:
+      if get_without_classname:
+        names_without_path.append(
+          powerfactory_object.loc_name)
+      else:
+        names_without_path.append(
+          powerfactory_object.loc_name
+          + '.'
+          + powerfactory_object.GetClassName())
 
-    names_without_path = [
-      _get_part_after_last_slash(x) for x in name_strings
-    ]
-    if get_without_classname:
-      names_without_path = [
-        _remove_classname(x) for x in names_without_path
-      ] 
+    if not is_list:
+      names_without_path = names_without_path[0]  
     return names_without_path
     
 

--- a/src/powfacpy/base_interface.py
+++ b/src/powfacpy/base_interface.py
@@ -856,6 +856,36 @@ class PFStringManipuilation:
     except(TypeError):
       raise TypeError("Path must be of type string.")
 
+  @staticmethod
+  def get_names_without_path(
+    powerfactory_objects, 
+    get_without_classname=False,
+    ):
+
+    if not type(powerfactory_objects) == list:
+      return_list = False = [powerfactory_objects,]
+    
+    name_strings = [
+      x.GetFullName() for x in  powerfactory_objects
+    ]
+
+    def _get_part_after_last_slash(x:str):
+      return x.split(r'\')[-1]
+    
+    def _remove_classname(x:str):
+      return x.split('.')[0]
+
+    names_without_path = [
+      _get_part_after_last_slash(x) for x in name_strings
+    ]
+    if get_without_classname:
+      names_without_path = [
+        _remove_classname(x) for x in names_without_path
+      ] 
+    return names_without_path
+    
+
+
   
 class PFResultVariable:
 

--- a/src/powfacpy/base_interface.py
+++ b/src/powfacpy/base_interface.py
@@ -811,6 +811,25 @@ class PFBaseInterface:
     obj_low = PFStringManipulation.format_full_path(str(obj_low),self)
     path = str(obj_low).split(str(obj_high))[1][1:] 
     return path     
+  
+  @staticmethod
+  def get_loc_name_with_class(powerfactory_objects):
+
+    is_list = True
+    if not type(powerfactory_objects) == list:
+      powerfactory_objects = [powerfactory_objects,]
+      is_list = False
+
+    loc_name_with_class = []
+    for powerfactory_object in powerfactory_objects:
+      loc_name_with_class.append(
+        powerfactory_object.loc_name
+        + '.'
+        + powerfactory_object.GetClassName())
+
+    if not is_list:
+      loc_name_with_class = loc_name_with_class[0]  
+    return loc_name_with_class
 
 
 class PFStringManipulation:
@@ -855,27 +874,6 @@ class PFStringManipulation:
         return path[1:] 
     except(TypeError):
       raise TypeError("Path must be of type string.")
-
-  @staticmethod
-  def get_loc_name_with_class(powerfactory_objects):
-    
-    is_list = True
-    if not type(powerfactory_objects) == list:
-      powerfactory_objects = [powerfactory_objects,]
-      is_list = False
-
-    loc_name_with_class = []
-    for powerfactory_object in powerfactory_objects:
-      loc_name_with_class.append(
-        powerfactory_object.loc_name
-        + '.'
-        + powerfactory_object.GetClassName())
-
-    if not is_list:
-      loc_name_with_class = loc_name_with_class[0]  
-    return loc_name_with_class
-    
-
 
   
 class PFResultVariable:

--- a/src/powfacpy/base_interface.py
+++ b/src/powfacpy/base_interface.py
@@ -857,30 +857,23 @@ class PFStringManipulation:
       raise TypeError("Path must be of type string.")
 
   @staticmethod
-  def get_names_without_path(
-    powerfactory_objects, 
-    get_without_classname=False,
-    ):
-
+  def get_loc_name_with_class(powerfactory_objects):
+    
     is_list = True
     if not type(powerfactory_objects) == list:
       powerfactory_objects = [powerfactory_objects,]
       is_list = False
 
-    names_without_path = []
+    loc_name_with_class = []
     for powerfactory_object in powerfactory_objects:
-      if get_without_classname:
-        names_without_path.append(
-          powerfactory_object.loc_name)
-      else:
-        names_without_path.append(
-          powerfactory_object.loc_name
-          + '.'
-          + powerfactory_object.GetClassName())
+      loc_name_with_class.append(
+        powerfactory_object.loc_name
+        + '.'
+        + powerfactory_object.GetClassName())
 
     if not is_list:
-      names_without_path = names_without_path[0]  
-    return names_without_path
+      loc_name_with_class = loc_name_with_class[0]  
+    return loc_name_with_class
     
 
 

--- a/src/powfacpy/base_interface.py
+++ b/src/powfacpy/base_interface.py
@@ -1,5 +1,5 @@
 """Contains the class PFBaseInterface (interaction with the PF database)
-and the class PFStringManipuilation for string manipulation.
+and the class PFStringManipulation for string manipulation.
 
 The abbreviation 'PF' is sometimes used for 'PowerFactory'.
 """

--- a/src/powfacpy/base_interface.py
+++ b/src/powfacpy/base_interface.py
@@ -863,14 +863,14 @@ class PFStringManipulation:
     ):
 
     if not type(powerfactory_objects) == list:
-      return_list = False = [powerfactory_objects,]
+      powerfactory_objects = [powerfactory_objects,]
     
     name_strings = [
       x.GetFullName() for x in  powerfactory_objects
     ]
 
     def _get_part_after_last_slash(x:str):
-      return x.split(r'\')[-1]
+      return x.split('\\')[-1]
     
     def _remove_classname(x:str):
       return x.split('.')[0]

--- a/src/powfacpy/base_interface.py
+++ b/src/powfacpy/base_interface.py
@@ -207,7 +207,7 @@ class PFBaseInterface:
           return False
         else:
           parent_path = parent.GetFullName()
-          parent_path = PFStringManipuilation.delete_classes(parent_path)
+          parent_path = PFStringManipulation.delete_classes(parent_path)
           existing_path = f"{parent_path}{existing_path}" 
           non_existent_child_name = child_name
           return False,existing_path,non_existent_child_name
@@ -258,13 +258,13 @@ class PFBaseInterface:
       except(AttributeError) as e:
         raise powfacpy.PFAttributeError(obj,e,self)
       except(TypeError) as e:
-        object_str = powfacpy.PFStringManipuilation.format_full_path(str(obj),self)
+        object_str = powfacpy.PFStringManipulation.format_full_path(str(obj),self)
         raise TypeError(f"{e}. Maybe an unexpected type is used "
           f"for attribute of object '{object_str}'.")  
     return objects_true
   
   def get_path_of_object(self,obj):
-    return PFStringManipuilation.format_full_path(str(obj),self)
+    return PFStringManipulation.format_full_path(str(obj),self)
 
   def get_attr(self,obj,attr,parent_folder=None):
     """Get the value of an attribute of an object.
@@ -734,7 +734,7 @@ class PFBaseInterface:
       variables = read_file.readline().split(",")
       for col,path in enumerate(full_paths):
           if col > 0:
-              formated_path = powfacpy.PFStringManipuilation.format_full_path(path,self)
+              formated_path = powfacpy.PFStringManipulation.format_full_path(path,self)
               variable_name = variables[col].split(" ", 1)[0].replace("\"","").replace("\n","") # get rid of description and quotation marks
               row = row + formated_path + "\\" + variable_name + "," # consistently add headers to row
           else:
@@ -806,14 +806,14 @@ class PFBaseInterface:
       object_low: Object lower in the hierarchy. 
     """
     obj_high = self.handle_single_pf_object_or_path_input(obj_high)
-    obj_high = PFStringManipuilation.format_full_path(str(obj_high),self)
+    obj_high = PFStringManipulation.format_full_path(str(obj_high),self)
     obj_low = self.handle_single_pf_object_or_path_input(obj_low)
-    obj_low = PFStringManipuilation.format_full_path(str(obj_low),self)
+    obj_low = PFStringManipulation.format_full_path(str(obj_low),self)
     path = str(obj_low).split(str(obj_high))[1][1:] 
     return path     
 
 
-class PFStringManipuilation:
+class PFStringManipulation:
   
   @staticmethod
   def replace_between_characters(char1,char2,replacement,string):
@@ -831,7 +831,7 @@ class PFStringManipuilation:
 
   @staticmethod
   def delete_classes(path):
-    return PFStringManipuilation.replace_between_characters('.','\\','\\',path)
+    return PFStringManipulation.replace_between_characters('.','\\','\\',path)
 
   @staticmethod
   def format_full_path(path,pf_interface):
@@ -844,7 +844,7 @@ class PFStringManipuilation:
     """
     project_name = pf_interface.app.GetActiveProject().loc_name + '.IntPrj\\'
     path = path[path.find(project_name)+len(project_name):]
-    return PFStringManipuilation.delete_classes(path)
+    return PFStringManipulation.delete_classes(path)
   
   @staticmethod
   def handle_path(path):

--- a/src/powfacpy/exceptions.py
+++ b/src/powfacpy/exceptions.py
@@ -14,7 +14,7 @@ class PFAttributeError(PFInterfaceError):
   """Attempt to access an invalid attribute of a PF object.
   """
   def __init__(self,obj,msg_raised,pf_base_interface):
-    object_str = powfacpy.PFStringManipuilation.format_full_path(str(obj),pf_base_interface)
+    object_str = powfacpy.PFStringManipulation.format_full_path(str(obj),pf_base_interface)
     self.message = (f"Unexpected attribute of object '{object_str}': {msg_raised}.")
     super().__init__(self.message)
 
@@ -22,7 +22,7 @@ class PFAttributeTypeError(PFInterfaceError):
   """Attempt to set an invalid type for the attribute of a PF object.
   """
   def __init__(self,obj,attr,msg_raised,pf_base_interface):
-    object_str = powfacpy.PFStringManipuilation.format_full_path(str(obj),pf_base_interface)
+    object_str = powfacpy.PFStringManipulation.format_full_path(str(obj),pf_base_interface)
     self.message = (f"The attribute '{attr}' of the object '{object_str}' "
       f"is of unexpected type: {msg_raised}.")
     super().__init__(self.message)
@@ -46,7 +46,7 @@ class PFNonExistingObjectError(PFInterfaceError):
   """Attempt to access PF object that does not exist.
   """
   def __init__(self,folder,obj,condition=False,include_subfolders=False):
-    folder_str = powfacpy.PFStringManipuilation.delete_classes(str(folder))
+    folder_str = powfacpy.PFStringManipulation.delete_classes(str(folder))
     if include_subfolders:
       msg_subfolder = " (and its subfolders)"
     else:

--- a/tests/test_base_interface.py
+++ b/tests/test_base_interface.py
@@ -239,5 +239,10 @@ def test_create_directory(pfbi,activate_test_project):
     pfbi.create_directory(r"test1\test2")
     pfbi.delete_obj("test1")
 
+def test_get_loc_name_with_class(pfbi,activate_test_project):
+    pf_objects = pfbi.get_obj(r'*.ElmTerm', include_subfolders=True)
+    pfbi.get_loc_name_with_class(pf_objects)
+    pfbi.get_loc_name_with_class(pf_objects[0])
+
 if __name__ == "__main__":
     pytest.main(([r"tests\test_base_interface.py"]))


### PR DESCRIPTION
Adds the function get_loc_name_with_class() to base_interface. 
Returns local name (loc_name, i.e. name without the whole object path like it's returned by PFObject.GetFullPath()),
but including the class of the object. 
'objectname.classname'
