### PR TITLE
Add settings.json for local settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tutorials/.ipynb_checkpoints
 py_venv
 *.csv
 .vscode
+/settings.json

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,3 @@
+{
+"local path to PowerFactory application": "C:\\Program Files\\DIgSILENT\\PowerFactory 2023 SP3\\Python\\3.10"
+}

--- a/tests/test_base_interface.py
+++ b/tests/test_base_interface.py
@@ -1,7 +1,10 @@
 import pytest
 import sys
 import os
-sys.path.append(r'C:\Program Files\DIgSILENT\PowerFactory 2022 SP1\Python\3.10')
+import json
+settings_file = open('.\\settings.json')
+settings = json.load(settings_file)
+sys.path.append(settings["local path to PowerFactory application"])
 import powerfactory
 sys.path.insert(0, r'.\src')
 import powfacpy 


### PR DESCRIPTION
Some settings depend on the local envrionment (e.g. the path to the PowerFactory application). settings.json was created for such settings. It can be adjusted by each user locally and is ignored by git.