### PR TITLE
fix get_path_of_object

### DIFF
--- a/src/powfacpy/base_interface.py
+++ b/src/powfacpy/base_interface.py
@@ -897,21 +897,21 @@ class PFStringManipulation:
     """
     new_string = ""
     is_after_char_1 = False
-    string_between_char_1_occurences = ""
+    string_between_char_1_occurrences = ""
     for c in original:
       if c == char1:
         is_after_char_1 = True
-        new_string += string_between_char_1_occurences
-        string_between_char_1_occurences = ""
+        new_string += string_between_char_1_occurrences
+        string_between_char_1_occurrences = ""
       elif c == char2:
         if is_after_char_1:
           new_string += replacement
         else:
           new_string += c 
-        string_between_char_1_occurences = ""  
+        string_between_char_1_occurrences = ""  
         is_after_char_1 = False
       if is_after_char_1:
-        string_between_char_1_occurences += c
+        string_between_char_1_occurrences += c
       elif not c == char2:
         new_string += c  
     return new_string   

--- a/src/powfacpy/base_interface.py
+++ b/src/powfacpy/base_interface.py
@@ -888,7 +888,7 @@ class PFStringManipulation:
         powfacpy.PFStringManipulation.replace_between_characters(
           '.', 
           '\\', 
-          '', 
+          '\\', 
           'username.IntUser\\pow.facpy.\\powfacpy.tests.IntPrj\\Network Model.IntPrjfolder\\Network Data.IntPrjfolder\\test_base_interface\\Grid.ElmNet\\Terminal HV 1.ElmTerm'
       would give the output:
         'username\\pow.facpy\\powfacpy.tests\\Network Model\\Network Data\\test_base_interface\\Grid\\Terminal HV 1' 

--- a/src/powfacpy/base_interface.py
+++ b/src/powfacpy/base_interface.py
@@ -881,17 +881,39 @@ class PFBaseInterface:
 class PFStringManipulation:
   
   @staticmethod
-  def replace_between_characters(char1, char2, replacement, string):
+  def replace_between_characters(char1, char2, replacement: str, original: str):
+    """
+    Example:
+      Calling      
+        powfacpy.PFStringManipulation.replace_between_characters(
+          '.', 
+          '\\', 
+          '', 
+          'username.IntUser\\pow.facpy.\\powfacpy.tests.IntPrj\\Network Model.IntPrjfolder\\Network Data.IntPrjfolder\\test_base_interface\\Grid.ElmNet\\Terminal HV 1.ElmTerm'
+      would give the output:
+        'username\\pow.facpy\\powfacpy.tests\\Network Model\\Network Data\\test_base_interface\\Grid\\Terminal HV 1' 
+      Note the behavior when there are several '.' in between '\\' 
+      -> then the replacement starts after the last '.'
+    """
     new_string = ""
-    is_between_chars = False
-    for c in string:
+    is_after_char_1 = False
+    string_between_char_1_occurences = ""
+    for c in original:
       if c == char1:
-        is_between_chars = True
-      elif c == char2 and is_between_chars:
-        is_between_chars = False
-        new_string = new_string + replacement
-      elif not is_between_chars:
-        new_string = new_string + c
+        is_after_char_1 = True
+        new_string += string_between_char_1_occurences
+        string_between_char_1_occurences = ""
+      elif c == char2:
+        if is_after_char_1:
+          new_string += replacement
+        else:
+          new_string += c 
+        string_between_char_1_occurences = ""  
+        is_after_char_1 = False
+      if is_after_char_1:
+        string_between_char_1_occurences += c
+      elif not c == char2:
+        new_string += c  
     return new_string   
 
   @staticmethod

--- a/tests/test_base_interface.py
+++ b/tests/test_base_interface.py
@@ -292,7 +292,13 @@ def test_replace_outside_or_inside_of_strings_in_a_string(pfbi, activate_test_pr
 	    conditions, {"control 1": "x[1]"}, outside=False)    
     assert(conditions == "lorem ipsum control 1 == 'ABC x[1]' 'x[1]'")
 
+def test_get_path_of_object(pfbi, activate_test_project):
+    path = "Network Model\\Network Data\\test_base_interface\\Grid\\Line 1.2"
+    line = pfbi.get_unique_obj(path)    
+    path_derived = pfbi.get_path_of_object(line)
+    print(path_derived)
+    assert (path==path_derived)
 
 if __name__ == "__main__":
-    pytest.main([r"tests\test_base_interface.py"])
+    pytest.main([r"tests\test_base_interface.py::test_get_path_of_object"])
     # pytest.main(([r"tests"]))

--- a/tests/test_base_interface.py
+++ b/tests/test_base_interface.py
@@ -296,7 +296,6 @@ def test_get_path_of_object(pfbi, activate_test_project):
     path = "Network Model\\Network Data\\test_base_interface\\Grid\\Line 1.2"
     line = pfbi.get_unique_obj(path)    
     path_derived = pfbi.get_path_of_object(line)
-    print(path_derived)
     assert (path==path_derived)
 
 if __name__ == "__main__":


### PR DESCRIPTION
This method did not work correctly when there are file names that contain "." e.g. an object like Term.inal.ElmTerm (formerly "inal" would have been deleted in the returned path)