### PR TITLE
Feature database interface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 dependencies = [
     "pandas > 1",
     "matplotlib > 1",
+    "jsondiff >= 2",
 ]
 
 [project.urls]

--- a/src/powfacpy/__init__.py
+++ b/src/powfacpy/__init__.py
@@ -11,5 +11,5 @@ from .network_interface import *
 from .engineering_helpers import *
 from .results_interface import *
 from .script_interface import *
-
+from .database_interface import *
 # 

--- a/src/powfacpy/base_interface.py
+++ b/src/powfacpy/base_interface.py
@@ -919,12 +919,16 @@ class PFStringManipulation:
       output: Network Model.IntPrjfolder\\Network Data.IntPrjfolder\\Grid.ElmNet\\Terminal 1.ElmTerm
     """
     project_name = pf_interface.app.GetActiveProject().loc_name + '.IntPrj\\'
-    path = path[path.find(project_name)+len(project_name):] 
+    path = PFStringManipulation.truncate_until_string(path, project_name) 
     # In case a closing tag occurs at the end of the path </l3> (e.g. when 
     # str() is called on a PF object, make sure this is removed.
     if path[-1] == ">":
       path = path[0:path.rfind("<")]
     return path 
+
+  @staticmethod
+  def truncate_until_string(original: str, string_pattern:str):
+    return original[original.find(string_pattern)+len(string_pattern):]
 
   @staticmethod
   def _format_full_path(path, pf_interface):

--- a/src/powfacpy/database_interface.py
+++ b/src/powfacpy/database_interface.py
@@ -1,0 +1,81 @@
+import sys
+sys.path.insert(0, r'.\src')
+import powfacpy
+from fnmatch import fnmatchcase
+
+class PFDatabaseInterface(powfacpy.PFBaseInterface):
+  language = powfacpy.PFBaseInterface.language
+  
+  def __init__(self, app):
+    super().__init__(app)
+
+  def get_object_attributes(
+      self,
+      objs,
+      class_attributes: dict = None,
+      relative_path: str = "") -> dict:
+    """
+    
+    """
+    if not class_attributes:
+      class_attributes = {"*":[]}
+    if relative_path:
+      relative_path = self.get_path_of_obj_with_class_names_relative_to_project(relative_path)  
+    
+    obj_attr_dict = {}
+    for obj in objs:
+      obj_path = self.get_path_of_obj_with_class_names_relative_to_project(obj)
+      if relative_path:
+        obj_path = obj_path[obj_path.find(relative_path)+len(relative_path)+1:]
+      obj_attr_dict[obj_path] = {}
+      for class_name in class_attributes.keys():
+        if fnmatchcase(obj.GetClassName(), class_name):
+          for attr in class_attributes[class_name]:
+            obj_attr_dict[obj_path][attr] = self._handle_attribute_type_for_reading(obj,attr)
+    return obj_attr_dict
+  
+  def set_object_attributes(
+      self,
+      obj_attr_dict: dict,
+      relative_path: str = ""):
+    """
+    
+    """
+    for obj, attr_key_val in obj_attr_dict.items():
+      if relative_path:
+        obj = relative_path + "\\" + obj
+      obj = self.get_unique_obj(obj)
+      for attr, value in attr_key_val.items():
+        if isinstance(value, str):
+          if not isinstance(obj.GetAttributeType(attr), str):
+            print(attr)
+            print(value)
+            value_pf_obj = self.get_unique_obj(value, error_if_non_existent=False)
+            
+            if value_pf_obj:
+              print(value_pf_obj)
+              value = value_pf_obj 
+              
+        self.set_attr(obj, {attr: value})  
+
+  def _handle_attribute_type_for_reading(
+      self,
+      obj,
+      attr,
+      pf_obj_handling="path",
+      relative_path=""):
+    attr_value = self.get_attr(obj,attr)
+    if isinstance(attr_value, (str, int, float)) or not attr_value:
+      return attr_value
+    else:
+      if pf_obj_handling == "path":
+        if relative_path:
+          relative_path = self.get_path_of_obj_with_class_names_relative_to_project(relative_path)    
+        return self.get_path_of_obj_with_class_names_relative_to_project(attr_value)
+      elif pf_obj_handling == "original_pf_obj":
+        return attr_value 
+      
+  def get_standard_class_attributes():
+    return {
+      "ElmTerm": ["Unom"]  
+    }

--- a/src/powfacpy/database_interface.py
+++ b/src/powfacpy/database_interface.py
@@ -53,16 +53,16 @@ class PFDatabaseInterface(powfacpy.PFBaseInterface):
         how to read the attribute (please see _handle_attribute_type_for_reading)
           
     Example return dict:
-     {
-     "Network Model.IntPrjfolder\\Network Data.IntPrjfolder\\test_database_interface\\Grid.ElmNet\\AC Voltage Source.ElmVac": {
-          "loc_name": "AC Voltage Source",
-          "bus1": "Network Model.IntPrjfolder\\Network Data.IntPrjfolder\\test_database_interface\\Grid.ElmNet\\Terminal HV 1.ElmTerm\\Cub_1.StaCubic",
-          "outserv": 0
-     },
-     "Network Model.IntPrjfolder\\Network Data.IntPrjfolder\\test_database_interface\\Grid.ElmNet\\Terminal HV 1.ElmTerm\\Cub_1.StaCubic": {
-          "loc_name": "Cub_1"
-     },
-     }
+    {
+      "Network Model.IntPrjfolder\\Network Data.IntPrjfolder\\test_database_interface\\Grid.ElmNet\\AC Voltage Source.ElmVac": {
+            "loc_name": "AC Voltage Source",
+            "bus1": "Network Model.IntPrjfolder\\Network Data.IntPrjfolder\\test_database_interface\\Grid.ElmNet\\Terminal HV 1.ElmTerm\\Cub_1.StaCubic",
+            "outserv": 0
+      },
+      "Network Model.IntPrjfolder\\Network Data.IntPrjfolder\\test_database_interface\\Grid.ElmNet\\Terminal HV 1.ElmTerm\\Cub_1.StaCubic": {
+            "loc_name": "Cub_1"
+      },
+    }
     """
     if not class_attributes:
       class_attributes = {"*": []} # no relevant attributes -> get only keys (object paths)

--- a/src/powfacpy/database_interface.py
+++ b/src/powfacpy/database_interface.py
@@ -29,7 +29,7 @@ class PFDatabaseInterface(powfacpy.PFBaseInterface):
     """
     Get dictionary with attributes of objects.
     The keys of the dictionary are the paths of the objects.
-    The values are dictionaries keys (attribute names) and values (attribute
+    The values are dictionaries with keys (attribute names) and values (attribute
     values), see "example return dict" below. 
     
     ToDo: pf_obj_handling="path"
@@ -73,7 +73,8 @@ class PFDatabaseInterface(powfacpy.PFBaseInterface):
     for obj in objs:
       obj_path = self.get_path_of_obj_with_class_names_relative_to_project(obj)
       if relative_path: 
-        obj_path = powfacpy.PFStringManipulation.truncate_until_string(relative_path + "\\") 
+        obj_path = powfacpy.PFStringManipulation.truncate_until_string(
+          obj_path,relative_path + "\\") 
       obj_attr_dict[obj_path] = {}
       for class_name in class_attributes.keys():
         if fnmatchcase(obj.GetClassName(), class_name):

--- a/src/powfacpy/database_interface.py
+++ b/src/powfacpy/database_interface.py
@@ -1,11 +1,12 @@
 """
-Use cases:
-- standard parameters for models/controllers
-- check if model was changed
+The database interface is helpful to interact with larger numbers
+of PF objects in the database (getting, setting, storing or comparing
+attributes).
+One use case is for example to define a set of standard parameters for a
+larger model. Using the interface, one can easily get, store (e.g. in a json file)
+and later reset a set of parameters.
 
-ToDo:
-- search for ToDo in this file
-- json export/import
+ToDo: Add tutorial for this interface (when there is more functionality).
 """
 
 
@@ -32,8 +33,6 @@ class PFDatabaseInterface(powfacpy.PFBaseInterface):
     The values are dictionaries with keys (attribute names) and values (attribute
     values), see "example return dict" below. 
     
-    ToDo: pf_obj_handling="path"
-    
     Arguments:
       - objs: Iterable with PF objects
       - class_attributes: dictionary with keys (class names) and values 
@@ -50,7 +49,8 @@ class PFDatabaseInterface(powfacpy.PFBaseInterface):
         Example: relative_path = "Network Model\\Network Data"
           -> Network Model.IntPrjfolder\\Network Data.IntPrjfolder\\test_database_interface\\Grid.ElmNet\\AC Voltage Source.ElmVac"
           becomes "test_database_interface\\Grid.ElmNet\\AC Voltage Source.ElmVac" (first part truncated)
-    
+      - pf_obj_handling: If the value of an attribute is a PF object, there are several options on 
+        how to read the attribute (please see _handle_attribute_type_for_reading)
           
     Example return dict:
      {
@@ -77,7 +77,7 @@ class PFDatabaseInterface(powfacpy.PFBaseInterface):
           obj_path,relative_path + "\\") 
       obj_attr_dict[obj_path] = {}
       for class_name in class_attributes.keys():
-        if fnmatchcase(obj.GetClassName(), class_name):
+        if fnmatchcase(obj.GetClassName(), class_name): # fnmatch allows to use wildcards ("*")
           for attr in class_attributes[class_name]:
             obj_attr_dict[obj_path][attr] = self._handle_attribute_type_for_reading(
               obj, attr, pf_obj_handling)
@@ -103,7 +103,7 @@ class PFDatabaseInterface(powfacpy.PFBaseInterface):
       obj = self.get_unique_obj(obj)
       for attr, value in attr_key_val.items():
         if isinstance(value, str):
-          if not isinstance(obj.GetAttributeType(attr), str):
+          if not isinstance(obj.GetAttributeType(attr), str): # Then a PF objeczt is expected
             value_pf_obj = self.get_unique_obj(value, error_if_non_existent=False)
             if value_pf_obj:
               value = value_pf_obj    

--- a/tests/test_database_interface.py
+++ b/tests/test_database_interface.py
@@ -23,13 +23,14 @@ def test_get_and_set_object_attributes(pfdbi, activate_test_project):
   Tests for getting and setting object attributes.
   The methods get_object_attributes and set_object_attributes can best be tested
   together by 
-    1. getting data of PF objects from the PF database
-    2. setting the data of the PF objects in the PF database with the output from 1.
-    3. again getting data of PF objects from the PF database
-    4. Checking if the output from 1. and 3. are equal. If so, gettind and setting
+    1. getting data of PF objects from the PF database.
+    2. modifiy some of the data.
+    3. setting the data of the PF objects in the PF database with the output from 2.
+    4. again getting data of PF objects from the PF database.
+    5. Checking if the output from 2. and 4. are equal. If so, gettind and setting
     data works correctly.
   This process is done with various optional arguments (relative_paths, pf_obj_handling_options).
-  The json file under 'tests\tests_output\test_get_object_attributes.json' can help with the 
+  The json files under 'tests\tests_output\test_get_object_attributes*.json' can help with the 
   interpretation of the operations.
   """
   truncated_paths = ["", r"Network Model\Network Data"]
@@ -38,7 +39,7 @@ def test_get_and_set_object_attributes(pfdbi, activate_test_project):
     for pf_obj_handling in pf_obj_handling_options:
       objs = pfdbi.get_obj("*",parent_folder=r"Network Model\Network Data\test_database_interface\Grid")
       class_attributes =  {
-        "*": ["loc_name", ],
+        "*": ["loc_name", "chr_name"],
         "ElmVac": ["bus1", "outserv"],
         "ElmTr2": ["typ_id"],    
       }
@@ -50,6 +51,12 @@ def test_get_and_set_object_attributes(pfdbi, activate_test_project):
       if pf_obj_handling == "path":
         with open(r'tests\tests_output\test_get_object_attributes.json', 'w') as json_file:
           json.dump(obj_attr_dict,json_file,indent=5)
+      # Modify data    
+      for obj in obj_attr_dict.keys():
+        obj_attr_dict[obj]["chr_name"] += "A"   
+      if pf_obj_handling == "path":
+        with open(r'tests\tests_output\test_get_object_attributes_modified.json', 'w') as json_file:       
+          json.dump(obj_attr_dict,json_file,indent=5)
       pfdbi.set_object_attributes(obj_attr_dict, added_path=truncated_path)  
       obj_attr_dict_after_reading_and_writing = pfdbi.get_object_attributes(
         objs,
@@ -60,5 +67,5 @@ def test_get_and_set_object_attributes(pfdbi, activate_test_project):
 
 
 if __name__ == "__main__":
-  # pytest.main([r"tests\test_database_interface.py"])
-  pytest.main(([r"tests"]))
+  pytest.main([r"tests\test_database_interface.py"])
+  # pytest.main(([r"tests"]))

--- a/tests/test_database_interface.py
+++ b/tests/test_database_interface.py
@@ -27,7 +27,7 @@ def test_get_and_set_object_attributes(pfdbi, activate_test_project):
     2. modifiy some of the data.
     3. setting the data of the PF objects in the PF database with the output from 2.
     4. again getting data of PF objects from the PF database.
-    5. Checking if the output from 2. and 4. are equal. If so, gettind and setting
+    5. Checking if the output from 2. and 4. are equal. If so, getting and setting
     data works correctly.
   This process is done with various optional arguments (relative_paths, pf_obj_handling_options).
   The json files under 'tests\tests_output\test_get_object_attributes*.json' can help with the 

--- a/tests/test_database_interface.py
+++ b/tests/test_database_interface.py
@@ -32,9 +32,9 @@ def test_get_and_set_object_attributes(pfdbi, activate_test_project):
   The json file under 'tests\tests_output\test_get_object_attributes.json' can help with the 
   interpretation of the operations.
   """
-  relative_paths = ["", r"Network Model\Network Data"]
+  truncated_paths = ["", r"Network Model\Network Data"]
   pf_obj_handling_options = ["path", "original_pf_obj"]
-  for relative_path in relative_paths:
+  for truncated_path in truncated_paths:
     for pf_obj_handling in pf_obj_handling_options:
       objs = pfdbi.get_obj("*",parent_folder=r"Network Model\Network Data\test_database_interface\Grid")
       class_attributes =  {
@@ -45,16 +45,16 @@ def test_get_and_set_object_attributes(pfdbi, activate_test_project):
       obj_attr_dict = pfdbi.get_object_attributes(
         objs,
         class_attributes = class_attributes,
-        relative_path = relative_path,
+        truncated_path = truncated_path,
         pf_obj_handling = pf_obj_handling) 
       if pf_obj_handling == "path":
         with open(r'tests\tests_output\test_get_object_attributes.json', 'w') as json_file:
           json.dump(obj_attr_dict,json_file,indent=5)
-      pfdbi.set_object_attributes(obj_attr_dict, relative_path=relative_path)  
+      pfdbi.set_object_attributes(obj_attr_dict, added_path=truncated_path)  
       obj_attr_dict_after_reading_and_writing = pfdbi.get_object_attributes(
         objs,
         class_attributes=class_attributes,
-        relative_path=relative_path,
+        truncated_path=truncated_path,
         pf_obj_handling = pf_obj_handling) 
       assert(not diff(obj_attr_dict, obj_attr_dict_after_reading_and_writing))
 

--- a/tests/test_database_interface.py
+++ b/tests/test_database_interface.py
@@ -1,0 +1,64 @@
+import pytest
+import sys
+import json
+settings_file = open('.\\settings.json')
+settings = json.load(settings_file)
+sys.path.append(settings["local path to PowerFactory application"])
+import powerfactory
+sys.path.insert(0, r'.\src')
+import powfacpy 
+import importlib
+importlib.reload(powfacpy)
+from jsondiff import diff
+
+from test_base_interface import pfbi, pf_app, activate_test_project
+
+@pytest.fixture
+def pfdbi(pf_app):
+  # Return PFDataBaseInterface instance
+  return powfacpy.PFDatabaseInterface(pf_app)
+
+def test_get_and_set_object_attributes(pfdbi, activate_test_project):
+  """
+  Tests for getting and setting object attributes.
+  The methods get_object_attributes and set_object_attributes can best be tested
+  together by 
+    1. getting data of PF objects from the PF database
+    2. setting the data of the PF objects in the PF database with the output from 1.
+    3. again getting data of PF objects from the PF database
+    4. Checking if the output from 1. and 3. are equal. If so, gettind and setting
+    data works correctly.
+  This process is done with various optional arguments (relative_paths, pf_obj_handling_options).
+  The json file under 'tests\tests_output\test_get_object_attributes.json' can help with the 
+  interpretation of the operations.
+  """
+  relative_paths = ["", r"Network Model\Network Data"]
+  pf_obj_handling_options = ["path", "original_pf_obj"]
+  for relative_path in relative_paths:
+    for pf_obj_handling in pf_obj_handling_options:
+      objs = pfdbi.get_obj("*",parent_folder=r"Network Model\Network Data\test_database_interface\Grid")
+      class_attributes =  {
+        "*": ["loc_name", ],
+        "ElmVac": ["bus1", "outserv"],
+        "ElmTr2": ["typ_id"],    
+      }
+      obj_attr_dict = pfdbi.get_object_attributes(
+        objs,
+        class_attributes = class_attributes,
+        relative_path = relative_path,
+        pf_obj_handling = pf_obj_handling) 
+      if pf_obj_handling == "path":
+        with open(r'tests\tests_output\test_get_object_attributes.json', 'w') as json_file:
+          json.dump(obj_attr_dict,json_file,indent=5)
+      pfdbi.set_object_attributes(obj_attr_dict, relative_path=relative_path)  
+      obj_attr_dict_after_reading_and_writing = pfdbi.get_object_attributes(
+        objs,
+        class_attributes=class_attributes,
+        relative_path=relative_path,
+        pf_obj_handling = pf_obj_handling) 
+      assert(not diff(obj_attr_dict, obj_attr_dict_after_reading_and_writing))
+
+
+if __name__ == "__main__":
+  # pytest.main([r"tests\test_database_interface.py"])
+  pytest.main(([r"tests"]))


### PR DESCRIPTION
The database interface is helpful to interact with larger numbers
of PF objects in the database (getting, setting, storing or comparing
attributes).
One use case is for example to define a set of standard parameters for a
larger model. Using the interface, one can easily get, store (e.g. in a json file)
and later reset a set of parameters.

@bertrtam00 you may start with this pull request